### PR TITLE
Add delete attachment route for internal appliations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,10 @@ services:
       - IPFS_HOST=ipfs
       - IDENTITY_SERVICE_HOST=identity-service
       - IDP_CLIENT_ID=sequence
-      - IDP_PUBLIC_URL_PREFIX=http://localhost:3080/realms/sequence/protocol/openid-connect
-      - IDP_INTERNAL_URL_PREFIX=http://keycloak:8080/realms/sequence/protocol/openid-connect
+      - IDP_PUBLIC_ORIGIN=http://localhost:3080
+      - IDP_INTERNAL_ORIGIN=http://keycloak:8080
+      - IDP_OAUTH2_REALM=sequence
+      - IDP_INTERNAL_REALM=internal
 
   postgres-attachment-api:
     image: postgres:17.4-alpine

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-attachment-api",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -2,29 +2,27 @@ import { z } from 'zod'
 import { UUID } from './strings.js'
 
 /**
- * File or JSON attachment
- * @example [{
+ * File attachment
+ * @example {
  *   "id": "string",
  *   "filename": "string",
  *   "size": 1024,
+ *   "integrityHash": "string",
+ *   "owner": "string",
  *   "createdAt": "2023-03-16T13:18:42.357Z"
- * }]
+ * }
  */
 export interface Attachment {
-  /**
-   * uuid generated using knex
-   */
   id: UUID
-  /**
-   * for json files name will be 'json'
-   */
   filename: string | 'json' | null
   size: number | null
+  integrityHash: string
+  owner: string
   createdAt: Date
 }
 
 export const internalAttachmentCreateBodyParser = z.object({
-  integrity_hash: z.string(),
+  integrityHash: z.string(),
   ownerAddress: z.string(),
 })
 export type InternalAttachmentCreateBody = z.infer<typeof internalAttachmentCreateBodyParser>

--- a/test/helper/routeHelper.ts
+++ b/test/helper/routeHelper.ts
@@ -70,6 +70,33 @@ export const postInternal = async (
   return request(app).post(endpoint).send(body).set(headersWithToken)
 }
 
+export const del = async (
+  app: express.Express,
+  endpoint: string,
+
+  headers: Record<string, string> = {}
+): Promise<request.Test> => {
+  const token = await getToken()
+  const headersWithToken = {
+    authorization: `bearer ${token}`,
+    ...headers,
+  }
+  return request(app).delete(endpoint).send().set(headersWithToken)
+}
+
+export const delInternal = async (
+  app: express.Express,
+  endpoint: string,
+  headers: Record<string, string> = {}
+): Promise<request.Test> => {
+  const token = await getToken('internal')
+  const headersWithToken = {
+    authorization: `bearer ${token}`,
+    ...headers,
+  }
+  return request(app).delete(endpoint).send().set(headersWithToken)
+}
+
 export const postFile = async (
   app: express.Express,
   endpoint: string,


### PR DESCRIPTION

# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [ ] Chore
- [x] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-126

## High level description

Adds `DELETE /v1/attachment/{id}` route for internal only

## Detailed description

Adds an internal route for deleting attachments from the db. We need this so the matchmaker can clean up if something goes wrong inserting blocks in to the db.

This also containers two three other minor fixes:
- fixes compose with scale on attachment service set to 1
- fixes type and documentation of returned attachment
- fixes casing on `integrityHash` parameter when doing create internal

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

None
