### PR TITLE
Chore/idp path prefix env

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Use a `.env` at root of the repository to set values for the environment variabl
 | IDP_CLIENT_ID          |    Y     |           -            | OAuth2 client-id to use in swagger-ui                                                                                                                 |
 | IDP_PUBLIC_ORIGIN      |    Y     |           -            | Origin of IDP from outside the cluster                                                                                                                |
 | IDP_INTERNAL_ORIGIN    |    Y     |           -            | Origin of IDP from inside the cluster                                                                                                                 |
+| IDP_PATH_PREFIX        |    N     |        `/auth`         | Path prefix to use when constructing IDP API paths.                                                                                                   |
 | IDP_OAUTH2_REALM       |    Y     |           -            | Realm to use when authenticating external users                                                                                                       |
 | IDP_INTERNAL_REALM     |    Y     |           -            | Realm to use when authenticating cluster internal users                                                                                               |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - IDP_CLIENT_ID=sequence
       - IDP_PUBLIC_ORIGIN=http://localhost:3080
       - IDP_INTERNAL_ORIGIN=http://keycloak:8080
+      - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=sequence
       - IDP_INTERNAL_REALM=internal
 
@@ -60,7 +61,7 @@ services:
       retries: 5
 
   sqnc-identity-service:
-    image: digicatapult/sqnc-identity-service:v4.0.4
+    image: digicatapult/sqnc-identity-service:v4.1.0
     container_name: identity-service
     depends_on:
       postgres-identity-service:
@@ -79,6 +80,7 @@ services:
       - IDP_CLIENT_ID=sequence
       - IDP_PUBLIC_ORIGIN=http://localhost:3080
       - IDP_INTERNAL_ORIGIN=http://keycloak:8080
+      - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=sequence
       - IDP_INTERNAL_REALM=internal
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-attachment-api",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -9,7 +9,9 @@ export const expressAuthentication = mergeAcceptAny([
     verifyOptions: {},
     securityName: 'oauth2',
     jwksUri: () =>
-      Promise.resolve(`${env.IDP_INTERNAL_ORIGIN}/realms/${env.IDP_OAUTH2_REALM}/protocol/openid-connect/certs`),
+      Promise.resolve(
+        `${env.IDP_INTERNAL_ORIGIN}${env.IDP_PATH_PREFIX}/realms/${env.IDP_OAUTH2_REALM}/protocol/openid-connect/certs`
+      ),
     getAccessToken: (req: express.Request) =>
       Promise.resolve(req.headers['authorization']?.substring('bearer '.length)),
     getScopesFromToken: async (decoded) => {
@@ -21,7 +23,9 @@ export const expressAuthentication = mergeAcceptAny([
     verifyOptions: {},
     securityName: 'internal',
     jwksUri: () =>
-      Promise.resolve(`${env.IDP_INTERNAL_ORIGIN}/realms/${env.IDP_INTERNAL_REALM}/protocol/openid-connect/certs`),
+      Promise.resolve(
+        `${env.IDP_INTERNAL_ORIGIN}${env.IDP_PATH_PREFIX}/realms/${env.IDP_INTERNAL_REALM}/protocol/openid-connect/certs`
+      ),
     getAccessToken: (req: express.Request) =>
       Promise.resolve(req.headers['authorization']?.substring('bearer '.length)),
     getScopesFromToken: async (decoded) => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,6 +34,10 @@ const env = envalid.cleanEnv(process.env, {
   IDP_INTERNAL_ORIGIN: envalid.url({
     devDefault: 'http://localhost:3080',
   }),
+  IDP_PATH_PREFIX: envalid.str({
+    default: '/auth',
+    devDefault: '',
+  }),
   IDP_OAUTH2_REALM: envalid.str({
     devDefault: 'sequence',
   }),

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -18,11 +18,11 @@ export default async function loadApiSpec(): Promise<unknown> {
   const swaggerJson = JSON.parse(swaggerBuffer.toString('utf8'))
   swaggerJson.info.title += `:${API_SWAGGER_HEADING}`
 
-  const tokenUrlOauth = `${env.IDP_PUBLIC_ORIGIN}/realms/${env.IDP_OAUTH2_REALM}/protocol/openid-connect/token`
+  const tokenUrlOauth = `${env.IDP_PUBLIC_ORIGIN}${env.IDP_PATH_PREFIX}/realms/${env.IDP_OAUTH2_REALM}/protocol/openid-connect/token`
   swaggerJson.components.securitySchemes.oauth2.flows.clientCredentials.tokenUrl = tokenUrlOauth
   swaggerJson.components.securitySchemes.oauth2.flows.clientCredentials.refreshUrl = tokenUrlOauth
 
-  const tokenUrlInternal = `${env.IDP_PUBLIC_ORIGIN}/realms/${env.IDP_INTERNAL_REALM}/protocol/openid-connect/token`
+  const tokenUrlInternal = `${env.IDP_PUBLIC_ORIGIN}${env.IDP_PATH_PREFIX}/realms/${env.IDP_INTERNAL_REALM}/protocol/openid-connect/token`
   swaggerJson.components.securitySchemes.internal.flows.clientCredentials.tokenUrl = tokenUrlInternal
   swaggerJson.components.securitySchemes.internal.flows.clientCredentials.refreshUrl = tokenUrlInternal
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-126

## High level description

Adds `IDP_PATH_PREFIX` env

## Detailed description

In production we offset keycloak onto a `/auth` path prefix using `KC_HOSTNAME_PATH` env. This wasn't a problem previously as we hadn't specifcially defined the format of the `IDP_INTERNAL_PREFIX` or similar. Now we construct the URLs in the application we specify this as an origin in the env name and docs and it would be odd to demand a path segment in there. This change introduces an optional variable to set the path prefix. 

I consider this a minor bump as it adds new configuration options. I've avoided a major by setting it to `/auth` by default which is our production value. I'll do a PR to the helm chart after this to carry through the configuration.

## Describe alternatives you've considered

We could just abuse the usage of the `IDP_INTERNAL_ORIGIN` and `IDP_PUBLIC_ORIGIN` args and allow the prefix to just be slapped on the end. This would work without change but is a bit odd. This also brings the change inline with how keycloak itself is configured

## Operational impact

None

## Additional context

None
