### PR TITLE
fetch attachments by hash or id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-attachment-api",
-      "version": "2.2.8",
+      "version": "2.2.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -26,3 +26,24 @@ export const internalAttachmentCreateBodyParser = z.object({
   ownerAddress: z.string(),
 })
 export type InternalAttachmentCreateBody = z.infer<typeof internalAttachmentCreateBodyParser>
+
+export const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+/**
+ * UUID format identifier
+ * @example 282439cd-ebc8-420e-bfbb-0de8fb3149ed
+ * @pattern ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+ */
+export type AttachmentId = string
+
+/**
+ * IPFS Content Identifier (CID) hash
+ * @example QmX5g1GwdB87mDoBTpTgfuWD2VKk8SpMj5WMFFGhhFacHN
+
+ */
+export type AttachmentHash = string
+
+/**
+ * Either an attachment UUID or an IPFS hash
+ */
+export type AttachmentIdOrHash = AttachmentId | AttachmentHash

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -37,13 +37,13 @@ export const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3
 export type AttachmentId = string
 
 /**
- * IPFS Content Identifier (CID) hash
+ * File integrity hash
  * @example QmX5g1GwdB87mDoBTpTgfuWD2VKk8SpMj5WMFFGhhFacHN
- * @pattern ^[a-zA-Z0-9]{1,44}$
+ * @pattern ^[a-zA-Z0-9]+$
  */
 export type AttachmentHash = string
 
 /**
- * Either an attachment UUID or an IPFS hash
+ * Either an attachment UUID or an file integrity hash
  */
 export type AttachmentIdOrHash = AttachmentId | AttachmentHash

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -39,7 +39,7 @@ export type AttachmentId = string
 /**
  * IPFS Content Identifier (CID) hash
  * @example QmX5g1GwdB87mDoBTpTgfuWD2VKk8SpMj5WMFFGhhFacHN
-
+ * @pattern ^[a-zA-Z0-9]{1,44}$
  */
 export type AttachmentHash = string
 

--- a/test/integration/attachment.test.ts
+++ b/test/integration/attachment.test.ts
@@ -37,6 +37,16 @@ describe('attachment', () => {
   })
 
   describe('invalid requests', () => {
+    it('returns 422 when attempting to retrieve by not UUID', async () => {
+      const { status, body } = await get(app, '/v1/attachment/not-uuid')
+
+      expect(status).to.equal(422)
+      expect(body).to.have.keys(['fields', 'message', 'name'])
+      expect(body).to.contain({
+        name: 'ValidateError',
+        message: 'Validation failed',
+      })
+    })
     it('returns 404 if no records found', async () => {
       const { status, body } = await get(app, '/v1/attachment/afe7e60a-2fd8-43f9-9867-041f14e3e8f4')
 

--- a/test/integration/attachment.test.ts
+++ b/test/integration/attachment.test.ts
@@ -398,7 +398,7 @@ describe('attachment', () => {
     })
 
     it('returns first attachment when fetching by hash', async () => {
-      const res = await get(app, `/v1/attachment/hash1`, { accept: 'application/json' })
+      const res = await get(app, `/v1/attachment/hash1`, { accept: 'application/octet-stream' })
       expect(res.status).to.equal(200)
       expect(res.header).to.deep.contain({
         'content-disposition': 'attachment; filename="json"',

--- a/test/seeds/attachment.seed.ts
+++ b/test/seeds/attachment.seed.ts
@@ -36,3 +36,17 @@ export const attachmentSeed = async () => {
     updated_at: new Date(exampleDate2),
   })
 }
+
+export const additionalAttachmentSeed = async () => {
+  const db = container.resolve(Database)
+
+  await db.insert('attachment', {
+    id: parametersAttachmentId,
+    filename: 'test4.txt',
+    integrity_hash: 'hash1',
+    owner: selfAddress,
+    size: 42,
+    created_at: new Date(exampleDate),
+    updated_at: new Date(exampleDate),
+  })
+}

--- a/tsoa.json
+++ b/tsoa.json
@@ -66,7 +66,7 @@
             }
           }
         },
-        "/v1/attachment/{id}": {
+        "/v1/attachment/{idOrHash}": {
           "get": {
             "responses": {
               "200": {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [ ] Chore
- [x] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-129

## High level description

Allow fetching of attachments by hash or id. 

## Detailed description

Updates the attachment service `GET /attachment/{id}` to allow id to be either an `id` or by the `hash`. If we have multiple attachments by the same hash we return the first (these should be collision resistant).


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
