### PR TITLE
Add missing owner check on external fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-attachment-api",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -5,6 +5,7 @@ import { NotFound, HttpResponse } from './error-handler/index.js'
 import env from '../env.js'
 import { Status, serviceState } from './service-watcher/statusPoll.js'
 import { logger } from './logger.js'
+import AuthInternal from './authInternal.js'
 
 const identityResponseValidator = z.object({
   address: z.string(),
@@ -22,7 +23,7 @@ type IdentityHealthResponse = z.infer<typeof identityHealthValidator>
 export default class Identity {
   private URL_PREFIX: string
 
-  constructor() {
+  constructor(private auth: AuthInternal) {
     this.URL_PREFIX = `http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}`
   }
 
@@ -57,10 +58,10 @@ export default class Identity {
       }
     }
   }
-  getMemberByAlias = async (alias: string, authorization: string): Promise<IdentityResponse> => {
+  getMemberByAlias = async (alias: string): Promise<IdentityResponse> => {
     const res = await fetch(`${this.URL_PREFIX}/v1/members/${encodeURIComponent(alias)}`, {
       headers: {
-        authorization,
+        authorization: `bearer ${await this.auth.getInternalAccessToken()}`,
       },
     })
 
@@ -85,10 +86,10 @@ export default class Identity {
     throw new HttpResponse({})
   }
 
-  getMemberBySelf = async (authorization: string): Promise<IdentityResponse> => {
+  getMemberBySelf = async (): Promise<IdentityResponse> => {
     const res = await fetch(`${this.URL_PREFIX}/v1/self`, {
       headers: {
-        authorization,
+        authorization: `bearer ${await this.auth.getInternalAccessToken()}`,
       },
     })
 
@@ -99,5 +100,5 @@ export default class Identity {
     throw new HttpResponse({})
   }
 
-  getMemberByAddress = (alias: string, authorization: string) => this.getMemberByAlias(alias, authorization)
+  getMemberByAddress = (alias: string) => this.getMemberByAlias(alias)
 }

--- a/src/lib/utils/shared.ts
+++ b/src/lib/utils/shared.ts
@@ -1,15 +1,3 @@
-import type express from 'express'
-
-import { UnknownError } from '../error-handler/index.js'
-
 export function trim0x(input: string): string {
   return input.startsWith('0x') ? input.slice(2) : input
-}
-
-export function getAuthorization(req: express.Request): string {
-  const authorization = req.headers['authorization']
-  if (!authorization) {
-    throw new UnknownError()
-  }
-  return authorization
 }


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-132

## High level description

Adds a missing owner check from #37 

## Detailed description

#37 was missing a check when doing a fetch for an external user to make sure the attahcment they were accessing is owned by us. This fixes that.

Also switches to using internal auth for the identity request as this makes the code cleaner (also good practice)

## Describe alternatives you've considered

N/.A

## Operational impact

None 

## Additional context

N/A
