### PR TITLE
Replace compose images with Bitnami legacy

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -23,7 +23,7 @@ services:
       - ./docker/keycloak:/opt/keycloak/data/import
     command: start-dev --import-realm
   minio:
-    image: bitnami/minio:latest
+    image: bitnamilegacy/minio:latest
     container_name: minio
     ports:
       - 9000:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,7 @@ services:
       - 8080:8080
       - 5001:5001
   minio:
-    image: bitnami/minio:latest
+    image: bitnamilegacy/minio:latest
     container_name: minio
     ports:
       - 9000:9000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "3.2.28",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-attachment-api",
-      "version": "3.2.28",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-attachment-api",
-  "version": "3.2.28",
+  "version": "3.3.0",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

ENG-185; ENG-194

## High level description

As part of our move over to Bitnami's free-to-use legacy image repository, we need to swap out the existing Bitnami images in any compose files. In due course, this MinIO image will likely be replaced once we've settled on a long-term alternative (as part of ENG-194).